### PR TITLE
Fix memory service setup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,10 @@
 # docker-compose.yml
 
+version: '3.9'
+
+volumes:
+  claude-memory:
+
 networks:
   a0net: {}
 
@@ -7,27 +12,9 @@ services:
   memory:
     image: mcp/memory:latest
     container_name: memory
-    
-    # НЕ переопределяем entrypoint. Позволяем образу использовать свой собственный.
-    # Просто передаем ему нужные аргументы.
-    command:
-      - memory
-      - --transport
-      - http
-      - --port
-      - "4100"
-      
-    ports:
-      - "4100:4100"
-      
-    healthcheck:
-      # Эта команда проверит, отвечает ли порт 4100
-      test: ["CMD", "curl", "-f", "http://localhost:4100/health"]
-      interval: 15s         # Проверять каждые 15 секунд
-      timeout: 10s          # Ждать ответа 10 секунд
-      retries: 5            # 5 попыток перед тем, как считать сервис упавшим
-      start_period: 30s     # !!! КЛЮЧЕВОЕ ИЗМЕНЕНИЕ: Дать контейнеру 30 секунд на запуск ПЕРЕД первой проверкой
-      
+    stdin_open: true
+    volumes:
+      - claude-memory:/app/dist
     networks:
       - a0net
 
@@ -39,9 +26,6 @@ services:
     ports:
       - "50080:80"
     depends_on:
-      memory:
-        condition: service_healthy
-    environment:
-      MEMORY_URL: http://memory:4100
+      - memory
     networks:
       - a0net


### PR DESCRIPTION
## Summary
- configure version and volumes
- run `mcp/memory` with default entrypoint and persistent storage
- simplify agent-zero dependency on memory

## Testing
- `python3 - <<'PY'
import yaml, json
print(json.dumps(yaml.safe_load(open('docker-compose.yml')), indent=2))
PY`

------
https://chatgpt.com/codex/tasks/task_e_684452930e8c832db125785f6b25e2c6